### PR TITLE
Added systemd init support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ The `tpm2` hook should be placed immediately before the `encrypt` hook in
 `/etc/mkinitcpio.conf`.
 
     HOOKS="... block tpm2 encrypt filesystems ...
+    
+In case of systemd init the `sd-tpm2` hook should be used instead and placed 
+immediately before the `sd-encrypt` hook in `/etc/mkinitcpio.conf`.
+
+
+    HOOKS="... block sd-tpm2 sd-encrypt filesystems ...
 
 You may also need to add the `vfat` file system driver to the `MODULES` array:
 

--- a/hook_tpm2
+++ b/hook_tpm2
@@ -1,23 +1,66 @@
 #!/usr/bin/ash
 
-run_hook() {
-    local ckeyfile tpmkeypub tpmkeypriv tpmkeyparent tpmkeyindex tpmkeyoffset
-    local tpmkeysize tkdev tkarg1 tkarg2 tkarg3 resolved pcrextendnum
-    local pcrextendalg tpmload pcrbank unseal unsealout tpmok
+load_params() {
+    if [[ ! -f "$1" ]]; then
+        return;
+    fi
+    set -- $(cat $1)
+    for param in "$@"; do
+        case "$param" in
+            tpmkey=*)
+                tpmkey="${param#tpmkey=}"
+            ;;
+            tpmpcr=*)
+                tpmpcr="${param#tpmpcr=}"
+            ;;
+            tpmextend=*)
+                tpmextend="${param#tpmextend=}"
+            ;;
+            tpmextend=*)
+                tpmextend="${param#tpmextend=}"
+            ;;
+            tpmprompt=*)
+                tpmprompt="${param#tpmprompt=}"
+            ;;
+            tpmdev=*)
+                tpmdev="${param#tpmdev=}"
+            ;;
+            tpmckeyfile=*)
+                tpmckeyfile="${param#tpmckeyfile=}"
+            ;;
+        esac
+    done
+}
 
+load_defaults(){
     # This file will be loaded by the encrypt hook
-    ckeyfile="/crypto_keyfile.bin"
-
+    tpmckeyfile="/crypto_keyfile.bin"
     # Rootfs location for sealed key files
     tpmkeypub="/tpm_keyfile.pub"
     tpmkeypriv="/tpm_keyfile.priv"
-
     # TPM device
-    [ -z $tpmdev ] && tpmdev="/dev/tpmrm0"
+    tpmdev="/dev/tpmrm0"
+}
+
+process_params(){
+    load_defaults
+    # Load params from config file
+    load_params /etc/tpm2-encrypt/params
+    # Load kernel params
+    load_params /proc/cmdline
+}
+
+run_hook() {
+    local tpmkeypub tpmkeypriv tpmkeyparent tpmkeyindex tpmkeyoffset
+    local tpmkeysize tkdev tkarg1 tkarg2 tkarg3 resolved pcrextendnum
+    local pcrextendalg tpmload pcrbank unseal unsealout tpmok
+
+    process_params
+
     export TPM2TOOLS_TCTI="device:${tpmdev}"
 
     # Parse tpmkey command line parameter
-    if [ -n "$tpmkey" ]; then
+    if [[ -n "$tpmkey" ]]; then
         IFS=: read tkdev tkarg1 tkarg2 tkarg3 <<EOF
 $tpmkey
 EOF
@@ -109,10 +152,10 @@ EOF
             IFS="|"
             for pcrbank in $tpmpcr; do
                 if [ -n "$tpmkeyindex" ]; then
-                    unsealout=$(tpm2_nvread -Q $tpmkeyoffset $tpmkeysize -P "pcr:${pcrbank}" -o $ckeyfile "$tpmkeyindex" 2>&1)
+                    unsealout=$(tpm2_nvread -Q $tpmkeyoffset $tpmkeysize -P "pcr:${pcrbank}" -o $tpmckeyfile "$tpmkeyindex" 2>&1)
                     unseal=$?
                 else
-                    unsealout=$(tpm2_unseal -Q -c /tpmobject.ctx -p "pcr:${pcrbank}" -o "$ckeyfile" 2>&1)
+                    unsealout=$(tpm2_unseal -Q -c /tpmobject.ctx -p "pcr:${pcrbank}" -o "$tpmckeyfile" 2>&1)
                     unseal=$?
                 fi
                 if [ $unseal -eq 0 ]; then break; fi
@@ -142,7 +185,7 @@ EOF
         fi
 
         if [ $tpmok -eq 0 ]; then
-            rm -f "$ckeyfile"
+            rm -f "$tpmckeyfile"
             msg ":: TPM Could not decrypt LUKS key"
         fi
     fi
@@ -167,10 +210,11 @@ EOF
 }
 
 run_cleanuphook() {
+    process_params
     # Securely delete key if still present
-    if [ -f "$ckeyfile" ]; then
-        dd if=/dev/urandom of="$ckeyfile" bs=$(stat --printf="%s" "$ckeyfile") count=1 conv=notrunc >/dev/null 2>&1
-        rm -f "$ckeyfile"
+    if [ -f "$tpmckeyfile" ]; then
+        dd if=/dev/urandom of="$tpmckeyfile" bs=$(stat -c "%s" "$tpmckeyfile") count=1 conv=notrunc >/dev/null 2>&1
+        rm -f "$tpmckeyfile"
     fi
 }
 

--- a/install_sd_tpm2
+++ b/install_sd_tpm2
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+build() {
+    add_module "tpm_tis"
+    add_module "tpm_crb"
+
+    add_binary "/usr/bin/tpm2_unseal"
+    add_binary "/usr/bin/tpm2_load"
+    add_binary "/usr/bin/tpm2_nvread"
+    add_binary "/usr/bin/tpm2_pcrextend"
+    add_binary "/usr/bin/sha1sum"
+    add_binary "/usr/bin/sha224sum"
+    add_binary "/usr/bin/sha256sum"
+    add_binary "/usr/bin/sha384sum"
+    add_binary "/usr/bin/sha512sum"
+
+    add_binary "/usr/lib/libtss2-tcti-device.so.0"
+
+    add_file "/usr/bin/tpm2_encrypt"
+    add_file "/usr/lib/initcpio/hooks/tpm2"
+
+    add_systemd_unit "tpm2-unseal.service"
+    add_systemd_unit "tpm2-cleanup.service"
+    add_systemd_unit "cryptsetup-pre.target"
+
+    WANTS="/usr/lib/systemd/system/cryptsetup.target.wants"
+    mkdir -p "$BUILDROOT$WANTS"
+    add_symlink "$WANTS/cryptsetup-pre.target" "/usr/lib/systemd/system/cryptsetup-pre.target"
+
+    WANTS="/usr/lib/systemd/system/cryptsetup-pre.target.wants"
+    mkdir -p "$BUILDROOT$WANTS"
+    add_symlink "$WANTS/tpm2-unseal.service" "/usr/lib/systemd/system/tpm2-unseal.service"
+
+    WANTS="/usr/lib/systemd/system/initrd-cleanup.service.wants"
+    mkdir -p "$BUILDROOT$WANTS"
+    add_symlink "$WANTS/tpm2-cleanup.service" "/usr/lib/systemd/system/tpm2-cleanup.service"
+
+    [[ -f /etc/tpm2-encrypt/params ]] && add_file "/etc/tpm2-encrypt/params"
+
+    if [[ -f /etc/tpm2-encrypt/key.pub && -f /etc/tpm2-encrypt/key.priv ]]; then
+        add_file "/etc/tpm2-encrypt/key.pub"
+        add_file "/etc/tpm2-encrypt/key.priv"
+    fi
+
+}
+
+
+help() {
+    cat <<HELPEOF
+This hook allows for an encrypted root device to use a key sealed by a
+TPM 2.0. It should be placed immediately before the 'sd-encrypt' hook. After
+generating a TPM-sealed key, both 'tpmkey' and 'tpmpcr' should be
+specified on the kernel command line.
+
+'tpmkey' has several formats:
+
+  tpmkey=[device]:[path]:[handle]
+  tpmkey=[device]:[publicpath]:[privatepath]:[handle]
+  tpmkey=nvram:[index]
+  tpmkey=nvram:[index]:[offset]:[size]
+
+Where [device] represents the raw block device on which the key exists,
+[path] is the absolute base path of the keyfiles within the device, and
+[handle] is the TPM handle of the key's parent object. If only [path] is
+specified, '.pub' and '.priv' will be appended to the path to locate the
+public and private files, respectively. The absolute [publicpath] and
+[privatepath] can be specified separately if needed.
+
+If [device] is rootfs, the key files will be read from the initramfs root
+file system.
+
+Setting [device] to 'nvram' indicates that the key is stored in TPM NVRAM.
+In this case [index] is the NVRAM area index, [offset] is the offset of
+the key in bytes and [size] is the size of the key in bytes.
+
+'tpmpcr' should hold the TPM2 PCR bank specification that will unlock the
+sealed key. Multiple specs can be separated by a '|' and key decryption
+will be attempted with each set of banks.
+
+The 'tpmextend' parameter may be used to indicate a PCR to extend after the
+key has been unsealed:
+
+    tpmextend=[alg]:[pcrnum]
+
+Where [alg] is the bank algorithm and [pcrnum] is the PCR number to extend.
+
+If the 'tpmprompt' command line parameter is set, the user will be
+prompted for the parent encryption key password during boot. This password
+will be used while loading the sealed key. This option has no effect when
+the key is stored in NVRAM. Ex: tpmprompt=1
+HELPEOF
+}
+
+# vim: set ft=sh ts=4 sw=4 et:

--- a/tpm2-cleanup.service
+++ b/tpm2-cleanup.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Clean tpm2 unsealed key
+DefaultDependencies=no
+Before=initrd-cleanup.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/tpm2_encrypt cleanup
+
+[Install]
+WantedBy=cryptsetup.target

--- a/tpm2-unseal.service
+++ b/tpm2-unseal.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Unseal key from tpm2
+DefaultDependencies=no
+Before=cryptsetup-pre.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/tpm2_encrypt unseal
+
+[Install]
+WantedBy=cryptsetup-pre.target

--- a/tpm2_encrypt
+++ b/tpm2_encrypt
@@ -1,0 +1,77 @@
+#!/usr/bin/sh
+
+HOOK_SCRIPT=/usr/lib/initcpio/hooks/tpm2;
+
+err(){
+    echo $1 >&2;
+    echo "$1" | /usr/bin/systemd-cat --priority="err" --identifier="tpm2_encrypt"
+    exit;
+}
+
+msg(){
+    echo $1;
+    echo "$1" | /usr/bin/systemd-cat --priority="info" --identifier="tpm2_encrypt"
+    exit;
+}
+
+resolve_device(){
+    echo $1
+}
+
+process_unseal(){
+    modprobe tpm_tis;
+    modprobe tpm_crb;
+    modprobe rng_core;
+    run_hook;
+}
+
+process_cleanup(){
+    run_cleanuphook;
+}
+
+process_output(){
+    cat "/crypto_keyfile.bin";
+}
+
+process_help(){
+    cat <<HELPEOF
+Script adapts tpm2 unsealing init hook calls to systemd services.
+
+Usage:
+    # tpm2_encrypt [MODE]
+
+Modes:
+    - unseal
+        Unseals the key by tpm2 to /crypto_keyfile.bin
+    - cleanup
+        Removes the key file /crypto_keyfile.bin
+    - keyscript
+        Unseals the key by tpm2, outputs the key to STDOUT and cleans up the key.
+    - help
+        Shows this help.
+HELPEOF
+}
+
+process_command(){
+    case "$1" in
+        unseal)
+            process_unseal;
+        ;;
+        cleanup)
+            process_cleanup;
+        ;;
+        keyscript)
+            process_unseal;
+            process_output;
+            process_cleanup;
+        ;;
+        *)
+            process_help;
+        ;;
+    esac;
+}
+
+source $HOOK_SCRIPT;
+process_command $1
+
+# vim: set ft=sh ts=4 sw=4 et:


### PR DESCRIPTION
Hi, added systemd init support to your mkinicpio script. I added second mkinicpio hook called sd-tpm2, which adds two systemd services to initramfs and a script that works as adapter to your init hooks.